### PR TITLE
fix(Components): Import entire React namespace

### DIFF
--- a/src/components/UISref.tsx
+++ b/src/components/UISref.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {Component, PropTypes, createElement, cloneElement, isValidElement, ValidationMap} from 'react';
 import * as classNames from 'classnames';
 import UIRouterReact from '../index';

--- a/src/components/UISrefActive.tsx
+++ b/src/components/UISrefActive.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {Component, PropTypes, cloneElement, ValidationMap} from 'react';
 import * as classNames from 'classnames';
 import UIRouterReact, { UISref } from '../index';

--- a/src/components/UIView.tsx
+++ b/src/components/UIView.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {Component, PropTypes, ValidationMap, createElement, cloneElement, isValidElement} from 'react';
 import {ActiveUIView, ViewContext, ViewConfig, Transition, ResolveContext, applyPairs, extend} from "ui-router-core";
 import UIRouterReact from "../index";


### PR DESCRIPTION
When using TypeScript 2.x and React typings installed via `npm install --save-dev @types/react` on a dependent project, compilation will fail with an error that looks like the following:

```
ERROR in $PROJECT/node_modules/ui-router-react/components/UISrefActive.d.ts
(22,16): error TS2503: Cannot find namespace '__React'.

ERROR in $PROJECT/node_modules/ui-router-react/components/UISrefActive.d.ts
(23,19): error TS2503: Cannot find namespace '__React'.

ERROR in $PROJECT/node_modules/ui-router-react/components/UISref.d.ts
(14,19): error TS2503: Cannot find namespace '__React'.

ERROR in $PROJECT/node_modules/ui-router-react/components/UISref.d.ts
(15,13): error TS2503: Cannot find namespace '__React'.

ERROR in $PROJECT/node_modules/ui-router-react/components/UISref.d.ts
(16,17): error TS2503: Cannot find namespace '__React'.

ERROR in $PROJECT/node_modules/ui-router-react/components/UISref.d.ts
(17,18): error TS2503: Cannot find namespace '__React'.

ERROR in $PROJECT/node_modules/ui-router-react/components/UISref.d.ts
(18,20): error TS2503: Cannot find namespace '__React'.

ERROR in $PROJECT/node_modules/ui-router-react/components/UISref.d.ts
(24,15): error TS2503: Cannot find namespace '__React'.

ERROR in $PROJECT/node_modules/ui-router-react/components/UIView.d.ts
(29,15): error TS2503: Cannot find namespace '__React'.
```

Explicitly importing the entire React namespace as `React` appears to solve this issue.