### PR TITLE
Added `UIView` support for `ReactCSSTransitionGroup` in order to allow animations between transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ui-router-react",
-  "version": "0.3.0",
+  "name": "uditalias-ui-router-react",
+  "version": "0.3.1",
   "description": "State based routing for React",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@types/classnames": "0.0.31",
+    "@types/node": "^6.0.51",
     "@types/react": "^0.14.43",
     "@types/react-dom": "^0.14.18",
     "awesome-typescript-loader": "^2.2.4",
@@ -48,6 +49,7 @@
     "glob": "^7.0.5",
     "jest": "^17.0.3",
     "react": "^15.0.2",
+    "react-addons-css-transition-group": "^15.4.1",
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.0.2",
     "react-test-renderer": "^15.3.1",

--- a/src/components/UIView.tsx
+++ b/src/components/UIView.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {Component, PropTypes, ValidationMap, createElement, cloneElement, isValidElement} from 'react';
+var ReactCSSTransitionGroup = require('react-addons-css-transition-group');
 import {ActiveUIView, ViewContext, ViewConfig, Transition, ResolveContext, StateParams, applyPairs, extend} from "ui-router-core";
 import UIRouterReact from "../index";
 import {ReactViewConfig} from "../reactViews";
@@ -17,6 +18,14 @@ export interface Resolves {
   $transition$: Transition
 }
 
+export interface TransitionGroup {
+    appear?: boolean,
+    appearTimeout?: number,
+    name?: number,
+    enterTimeout?: number,
+    leaveTimeout?: number
+}
+
 export interface InjectedProps {
   transition?: Transition,
   resolves?: Resolves,
@@ -27,6 +36,7 @@ export interface InjectedProps {
 export interface IProps {
   name?: string;
   className?: string;
+  transitionGroup?: TransitionGroup;
   style?: Object;
 }
 
@@ -74,7 +84,7 @@ export class UIView extends Component<IProps, IState> {
   }
 
   render() {
-    let { children } = this.props;
+    let { children, transitionGroup } = this.props;
     let { component, props, loaded } = this.state;
     // register reference of child component
     // register new hook right after component has been rendered
@@ -84,9 +94,24 @@ export class UIView extends Component<IProps, IState> {
       this.registerUiCanExitHook(stateName);
     };
 
+    // add a key prop, for css transition group
+    props.key = stateName;
+
     let child = !loaded && isValidElement(children)
       ? cloneElement(children, props)
       : createElement(component, props);
+
+
+    if (transitionGroup) {
+      return React.createElement(ReactCSSTransitionGroup, {
+        transitionAppear: typeof transitionGroup.appear === "boolean" ? transitionGroup.appear : true,
+        transitionAppearTimeout: transitionGroup.appearTimeout || 0,
+        transitionName: transitionGroup.name || "",
+        transitionEnterTimeout: transitionGroup.enterTimeout || 0,
+        transitionLeaveTimeout: transitionGroup.leaveTimeout || 0
+      }, child);
+    }
+
     return child;
   }
 

--- a/src/history/browserHistory.ts
+++ b/src/history/browserHistory.ts
@@ -26,6 +26,7 @@ const locationServiceConfig: LocationConfig = {
 }
 
 const locationService: LocationServices = {
+  url: () => "",
   hash: () =>
       trimHashVal(location.hash),
   path: () => {

--- a/src/history/hashHistory.ts
+++ b/src/history/hashHistory.ts
@@ -26,6 +26,7 @@ const locationServiceConfig: LocationConfig = {
 }
 
 const locationService: LocationServices = {
+  url: () => "",
   hash: () =>
       splitHash(trimHashVal(location.hash))[1],
   path: () =>


### PR DESCRIPTION
- Added `UIView` support for `ReactCSSTransitionGroup` in order to allow animations between transitions.

- Added node typings to allow `require` (for some reason `import` didn't worked for `react-addons-css-transition-group`)