### PR TITLE
fix(UIRouter): Apply config before registering states

### DIFF
--- a/src/components/UIRouter.tsx
+++ b/src/components/UIRouter.tsx
@@ -69,8 +69,8 @@ export class UIRouter extends Component<UIRouterProps, UIRouterState> {
       this.router = new UIRouterReact();
       this.router.plugin(servicesPlugin);
       props.plugins.forEach(plugin => this.router.plugin(plugin));
-      (props.states || []).forEach(state => this.router.stateRegistry.register(state));
       if (props.config) props.config(this.router);
+      (props.states || []).forEach(state => this.router.stateRegistry.register(state));
     } else {
       throw InstanceOrPluginsMissingError;
     }


### PR DESCRIPTION
If the optional config applies something that state declarations depend
on, such as custom parameter type definitions, then it needs to be
applied *before* states are registered.