### PR TITLE
chore(*): add `react` to peer dependencies (fixes #40)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "es6-shim": "^0.35.1",
     "ui-router-core": "=4.0.0"
   },
+  "peerDependencies": {
+    "react": "^15.0.0 || ^16.0.0-alpha"
+  },
   "devDependencies": {
     "@types/classnames": "0.0.31",
     "@types/react": "^0.14.43",


### PR DESCRIPTION
react version `^16.0.0-alpha` is included to make it easier for people to test on next version without npm complaining about missing versions