### PR TITLE
refactor(*): switch to `prop-types` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "prop-types": "^15.5.8",
     "ui-router-core": "=4.0.0"
   },
   "peerDependencies": {
@@ -40,6 +41,7 @@
   },
   "devDependencies": {
     "@types/classnames": "0.0.31",
+    "@types/prop-types": "^15.5.1",
     "@types/react": "^0.14.43",
     "@types/react-dom": "^0.14.18",
     "awesome-typescript-loader": "^3.1.2",

--- a/src/components/UIRouter.tsx
+++ b/src/components/UIRouter.tsx
@@ -3,7 +3,8 @@
  * @module components
  */ /** */
 import * as React from 'react';
-import {Component, PropTypes, Children} from 'react';
+import {Component, Children} from 'react';
+import * as PropTypes from 'prop-types';
 import {UIRouterReact, ReactStateDeclaration} from '../index';
 import {UIRouterPlugin} from 'ui-router-core';
 import {servicesPlugin} from 'ui-router-core';

--- a/src/components/UIRouter.tsx
+++ b/src/components/UIRouter.tsx
@@ -4,10 +4,12 @@
  */ /** */
 import * as React from 'react';
 import {Component, Children} from 'react';
-import * as PropTypes from 'prop-types';
+import * as _PropTypes from 'prop-types';
 import {UIRouterReact, ReactStateDeclaration} from '../index';
 import {UIRouterPlugin} from 'ui-router-core';
 import {servicesPlugin} from 'ui-router-core';
+
+let PropTypes = _PropTypes;
 
 export interface UIRouterProps {
   plugins?: any[]; // should fix type

--- a/src/components/UIRouter.tsx
+++ b/src/components/UIRouter.tsx
@@ -4,12 +4,10 @@
  */ /** */
 import * as React from 'react';
 import {Component, Children} from 'react';
-import * as _PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 import {UIRouterReact, ReactStateDeclaration} from '../index';
 import {UIRouterPlugin} from 'ui-router-core';
 import {servicesPlugin} from 'ui-router-core';
-
-let PropTypes = _PropTypes;
 
 export interface UIRouterProps {
   plugins?: any[]; // should fix type

--- a/src/components/UISref.tsx
+++ b/src/components/UISref.tsx
@@ -4,13 +4,12 @@
  */ /** */
 import * as React from 'react';
 import {Component, createElement, cloneElement, isValidElement, ValidationMap} from 'react';
-import * as _PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 import * as _classNames from 'classnames';
 import {UIRouterReact} from '../index';
 import {extend, TransitionOptions} from 'ui-router-core';
 import {UIViewAddress} from "./UIView";
 
-let PropTypes = _PropTypes;
 let classNames = _classNames;
 
 export interface UISrefProps {

--- a/src/components/UISref.tsx
+++ b/src/components/UISref.tsx
@@ -4,12 +4,13 @@
  */ /** */
 import * as React from 'react';
 import {Component, createElement, cloneElement, isValidElement, ValidationMap} from 'react';
-import * as PropTypes from 'prop-types';
+import * as _PropTypes from 'prop-types';
 import * as _classNames from 'classnames';
 import {UIRouterReact} from '../index';
 import {extend, TransitionOptions} from 'ui-router-core';
 import {UIViewAddress} from "./UIView";
 
+let PropTypes = _PropTypes;
 let classNames = _classNames;
 
 export interface UISrefProps {

--- a/src/components/UISref.tsx
+++ b/src/components/UISref.tsx
@@ -3,7 +3,8 @@
  * @module components
  */ /** */
 import * as React from 'react';
-import {Component, PropTypes, createElement, cloneElement, isValidElement, ValidationMap} from 'react';
+import {Component, createElement, cloneElement, isValidElement, ValidationMap} from 'react';
+import * as PropTypes from 'prop-types';
 import * as _classNames from 'classnames';
 import {UIRouterReact} from '../index';
 import {extend, TransitionOptions} from 'ui-router-core';

--- a/src/components/UISrefActive.tsx
+++ b/src/components/UISrefActive.tsx
@@ -3,7 +3,8 @@
  * @module components
  */ /** */
 import * as React from 'react';
-import {Component, PropTypes, cloneElement, ValidationMap} from 'react';
+import {Component, cloneElement, ValidationMap} from 'react';
+import * as PropTypes from 'prop-types';
 import * as _classNames from 'classnames';
 import { UIRouterReact, UISref } from '../index';
 import {UIViewAddress} from "./UIView";

--- a/src/components/UISrefActive.tsx
+++ b/src/components/UISrefActive.tsx
@@ -4,11 +4,12 @@
  */ /** */
 import * as React from 'react';
 import {Component, cloneElement, ValidationMap} from 'react';
-import * as PropTypes from 'prop-types';
+import * as _PropTypes from 'prop-types';
 import * as _classNames from 'classnames';
 import { UIRouterReact, UISref } from '../index';
 import {UIViewAddress} from "./UIView";
 
+let PropTypes = _PropTypes;
 let classNames = _classNames;
 
 export interface UISrefActiveProps {

--- a/src/components/UISrefActive.tsx
+++ b/src/components/UISrefActive.tsx
@@ -4,12 +4,11 @@
  */ /** */
 import * as React from 'react';
 import {Component, cloneElement, ValidationMap} from 'react';
-import * as _PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 import * as _classNames from 'classnames';
 import { UIRouterReact, UISref } from '../index';
 import {UIViewAddress} from "./UIView";
 
-let PropTypes = _PropTypes;
 let classNames = _classNames;
 
 export interface UISrefActiveProps {

--- a/src/components/UIView.tsx
+++ b/src/components/UIView.tsx
@@ -4,11 +4,13 @@
  */ /** */
 import * as React from 'react';
 import {Component, ValidationMap, createElement, cloneElement, isValidElement} from 'react';
-import * as PropTypes from 'prop-types';
+import * as _PropTypes from 'prop-types';
 import {ReactElement, SFC, ClassType, StatelessComponent, ComponentClass, ClassicComponentClass} from 'react';
 import {ActiveUIView, ViewContext, ViewConfig, Transition, ResolveContext, StateParams, applyPairs, extend} from "ui-router-core";
 import {UIRouterReact} from "../index";
 import {ReactViewConfig} from "../reactViews";
+
+let PropTypes = _PropTypes;
 
 /** @internalapi */
 let id = 0;

--- a/src/components/UIView.tsx
+++ b/src/components/UIView.tsx
@@ -4,13 +4,11 @@
  */ /** */
 import * as React from 'react';
 import {Component, ValidationMap, createElement, cloneElement, isValidElement} from 'react';
-import * as _PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 import {ReactElement, SFC, ClassType, StatelessComponent, ComponentClass, ClassicComponentClass} from 'react';
 import {ActiveUIView, ViewContext, ViewConfig, Transition, ResolveContext, StateParams, applyPairs, extend} from "ui-router-core";
 import {UIRouterReact} from "../index";
 import {ReactViewConfig} from "../reactViews";
-
-let PropTypes = _PropTypes;
 
 /** @internalapi */
 let id = 0;

--- a/src/components/UIView.tsx
+++ b/src/components/UIView.tsx
@@ -3,7 +3,8 @@
  * @module components
  */ /** */
 import * as React from 'react';
-import {Component, PropTypes, ValidationMap, createElement, cloneElement, isValidElement} from 'react';
+import {Component, ValidationMap, createElement, cloneElement, isValidElement} from 'react';
+import * as PropTypes from 'prop-types';
 import {ReactElement, SFC, ClassType, StatelessComponent, ComponentClass, ClassicComponentClass} from 'react';
 import {ActiveUIView, ViewContext, ViewConfig, Transition, ResolveContext, StateParams, applyPairs, extend} from "ui-router-core";
 import {UIRouterReact} from "../index";

--- a/src/components/__tests__/UIRouter.test.tsx
+++ b/src/components/__tests__/UIRouter.test.tsx
@@ -1,11 +1,13 @@
 declare var jest, describe, it, expect, beforeEach;
 
 import * as React from "react";
-import * as PropTypes from "prop-types";
+import * as _PropTypes from "prop-types";
 import { shallow, mount, render } from "enzyme";
 import * as sinon from "sinon";
 
 import {UIRouter, UIRouterReact, ReactStateDeclaration, memoryLocationPlugin} from "../../index";
+
+let PropTypes = _PropTypes;
 
 class Child extends React.Component<any, any> {
   static contextTypes: React.ValidationMap<any> = {

--- a/src/components/__tests__/UIRouter.test.tsx
+++ b/src/components/__tests__/UIRouter.test.tsx
@@ -1,6 +1,7 @@
 declare var jest, describe, it, expect, beforeEach;
 
 import * as React from "react";
+import * as PropTypes from "prop-types";
 import { shallow, mount, render } from "enzyme";
 import * as sinon from "sinon";
 
@@ -8,7 +9,7 @@ import {UIRouter, UIRouterReact, ReactStateDeclaration, memoryLocationPlugin} fr
 
 class Child extends React.Component<any, any> {
   static contextTypes: React.ValidationMap<any> = {
-    router: React.PropTypes.object
+    router: PropTypes.object
   }
   render () {
     return <div>child</div>;

--- a/src/components/__tests__/UIRouter.test.tsx
+++ b/src/components/__tests__/UIRouter.test.tsx
@@ -1,13 +1,11 @@
 declare var jest, describe, it, expect, beforeEach;
 
 import * as React from "react";
-import * as _PropTypes from "prop-types";
+import * as PropTypes from "prop-types";
 import { shallow, mount, render } from "enzyme";
 import * as sinon from "sinon";
 
 import {UIRouter, UIRouterReact, ReactStateDeclaration, memoryLocationPlugin} from "../../index";
-
-let PropTypes = _PropTypes;
 
 class Child extends React.Component<any, any> {
   static contextTypes: React.ValidationMap<any> = {


### PR DESCRIPTION
This introduces new dependency on `prop-types` package as recommended in latest react:

https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html