### PR TITLE
Consider Switching UIView to PureComponent

### DIFF
--- a/src/components/UIView.tsx
+++ b/src/components/UIView.tsx
@@ -4,7 +4,7 @@
  */ /** */
 import * as React from 'react';
 import {
-  Component,
+  PureComponent,
   ValidationMap,
   createElement,
   cloneElement,
@@ -107,7 +107,7 @@ export interface UIViewState {
   props?: any;
 }
 
-export class UIView extends Component<UIViewProps, UIViewState> {
+export class UIView extends PureComponent<UIViewProps, UIViewState> {
   // This object contains all the metadata for this UIView
   uiViewData: ActiveUIView;
 


### PR DESCRIPTION
To prevent additional rerenders, UIView should only rerender when the props change.

I've been testing with [why-did-you-update](https://www.npmjs.com/package/why-did-you-update) and `<UIView>` appears to cause significant rerenders. I thought of trying PureComponent, but I am unable to test these changes locally. `npm run dev` does not work on this project, and `npm link`ing this project breaks mine. I'm not sure if there would be repercussions to using PureComponent without testing.