### PR TITLE
Inject resolves as root props

### DIFF
--- a/examples/typescript/components/Nest.tsx
+++ b/examples/typescript/components/Nest.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { UIViewInjectedProps } from '@uirouter/react';
 
-export class Nest extends React.Component<UIViewInjectedProps, any> {
+interface NextInjectedProps extends UIViewInjectedProps {
+  foo: string;
+}
+
+export class Nest extends React.Component<NextInjectedProps, any> {
   uiCanExit = () => {
     return new Promise(resolve => {
       setTimeout(() => {
@@ -11,7 +15,7 @@ export class Nest extends React.Component<UIViewInjectedProps, any> {
   };
 
   render() {
-    const { foo } = this.props.resolves;
+    const { foo } = this.props;
     return (
       <div>
         <h2>Nested</h2>

--- a/src/__tests__/core.test.tsx
+++ b/src/__tests__/core.test.tsx
@@ -4,8 +4,18 @@ import * as React from 'react';
 import { shallow, mount, render } from 'enzyme';
 import * as sinon from 'sinon';
 
-import { UIRouterReact, UIView, UISref, ReactStateDeclaration } from '../index';
-import { services, UrlMatcher } from 'ui-router-core';
+import {
+  UIRouterReact,
+  UIView,
+  UISref,
+  ReactStateDeclaration,
+  StartMethodCalledMoreThanOnceError,
+} from '../index';
+import {
+  servicesPlugin,
+  memoryLocationPlugin,
+  UrlMatcher,
+} from '@uirouter/core';
 
 describe('UIRouterReact class', () => {
   let router;
@@ -13,6 +23,8 @@ describe('UIRouterReact class', () => {
 
   beforeEach(() => {
     router = new UIRouterReact();
+    router.plugin(servicesPlugin);
+    router.plugin(memoryLocationPlugin);
     sandbox = sinon.sandbox.create();
   });
 
@@ -32,6 +44,6 @@ describe('UIRouterReact class', () => {
     expect(() => {
       router.start();
       router.start();
-    }).toThrow();
+    }).toThrow(StartMethodCalledMoreThanOnceError);
   });
 });

--- a/src/components/UIView.tsx
+++ b/src/components/UIView.tsx
@@ -107,6 +107,11 @@ export interface UIViewState {
   props?: any;
 }
 
+export const TransitionPropCollisionError = new Error(
+  '`transition` cannot be used as resolve token. ' +
+    'Please rename your resolve to avoid conflicts with the router transition.',
+);
+
 export class UIView extends Component<UIViewProps, UIViewState> {
   // This object contains all the metadata for this UIView
   uiViewData: ActiveUIView;
@@ -237,12 +242,16 @@ export class UIView extends Component<UIViewProps, UIViewState> {
 
       let ctx = new ResolveContext(newConfig.path);
       trans = ctx.getResolvable(Transition).data;
-      let stringTokens = trans
+      let stringTokens: string[] = trans
         .getResolveTokens()
         .filter(x => typeof x === 'string');
       resolves = stringTokens
         .map(token => [token, trans.injector().get(token)])
         .reduce(applyPairs, {});
+
+      if (stringTokens.indexOf('transition') !== -1) {
+        throw TransitionPropCollisionError;
+      }
     }
 
     this.uiViewData.config = newConfig;

--- a/src/components/UIView.tsx
+++ b/src/components/UIView.tsx
@@ -246,7 +246,7 @@ export class UIView extends Component<UIViewProps, UIViewState> {
     }
 
     this.uiViewData.config = newConfig;
-    let props = { resolves, transition: trans };
+    let props = { ...resolves, transition: trans };
 
     // attach any style or className to the rendered component
     // specified on the UIView itself

--- a/src/components/__tests__/UIView.test.tsx
+++ b/src/components/__tests__/UIView.test.tsx
@@ -121,7 +121,11 @@ describe('<UIView>', () => {
 
     it('injects the right props', () => {
       const Comp = () => <span>component</span>;
-      router.stateRegistry.register({ name: '__state', component: Comp });
+      router.stateRegistry.register({
+        name: '__state',
+        component: Comp,
+        resolve: [{ resolveFn: () => true, token: 'myresolve' }],
+      });
       const wrapper = mount(
         <UIRouter router={router}>
           <UIView />
@@ -129,7 +133,7 @@ describe('<UIView>', () => {
       );
       return router.stateService.go('__state').then(() => {
         wrapper.update();
-        expect(wrapper.find(Comp).props().resolves).not.toBeUndefined();
+        expect(wrapper.find(Comp).props().myresolve).not.toBeUndefined();
         expect(wrapper.find(Comp).props().transition).not.toBeUndefined();
       });
     });
@@ -148,7 +152,7 @@ describe('<UIView>', () => {
       );
       return router.stateService.go('__state').then(() => {
         wrapper.update();
-        expect(wrapper.find(Comp).props().resolves.foo).toBe('bar');
+        expect(wrapper.find(Comp).props().foo).toBe('bar');
       });
     });
 

--- a/src/components/__tests__/UIView.test.tsx
+++ b/src/components/__tests__/UIView.test.tsx
@@ -11,6 +11,7 @@ import {
   ReactStateDeclaration,
   memoryLocationPlugin,
   servicesPlugin,
+  TransitionPropCollisionError,
 } from '../../index';
 
 const states = [
@@ -154,6 +155,25 @@ describe('<UIView>', () => {
         wrapper.update();
         expect(wrapper.find(Comp).props().foo).toBe('bar');
       });
+    });
+
+    it('throws if a resolve uses the token `transition`', async () => {
+      const Comp = () => <span>component</span>;
+      router.stateRegistry.register({
+        name: '__state',
+        component: Comp,
+        resolve: [{ token: 'transition', resolveFn: () => null }],
+      });
+
+      await router.stateService.go('__state');
+
+      expect(() => {
+        const wrapper = mount(
+          <UIRouter router={router}>
+            <UIView />
+          </UIRouter>,
+        );
+      }).toThrow(TransitionPropCollisionError);
     });
 
     it('renders nested State Components', () => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -23,7 +23,7 @@ let viewConfigFactory = (node: [PathNode], config: ReactViewDeclaration) =>
   new ReactViewConfig(node, config);
 
 /** @hidden */
-const StartMethodCalledMoreThanOnceError = new Error(`
+export const StartMethodCalledMoreThanOnceError = new Error(`
   The Router.start() method has been called more than once.
 
   The <UIRouter> component calls start() as final step of the initialization and you shouldn't need to call it manually.

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,5 +15,5 @@ export * from './interface';
 export * from './reactViews';
 export * from './components/components';
 
-export { UIRouterReact } from './core';
+export { UIRouterReact, StartMethodCalledMoreThanOnceError } from './core';
 export { UIRouter } from './components/components';


### PR DESCRIPTION
As discussed in #55, with this PR each resolve is now injected as prop.

This opens up possible collision with the special `transition` props injected by the router. A warning has been added id this is the case.