### PR TITLE
Add 'module' entry to allow Webpack to tree shake it

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "jsnext:main": "lib-esm/index.js",
+  "module": "lib-esm/index.js",
   "scripts": {
     "patch": "patch -N -r patch.rej -p1 < node_modules/enzyme-context-patch/patches/enzyme-adapter-react-16+1.1.1.patch || true && shx rm -f patch.rej",
     "test": "npm run patch && NODE_ENV=production jest --silent",


### PR DESCRIPTION
Bundlers such as Webpack are not support `jsnext:main` entry, but do support `module`.

I've just added that entry, I've checked on my build, and webpack was able to enable module concat optimisation and tree shaking.