### PR TITLE
Refactor: add interface to UISref Component props

### DIFF
--- a/src/components/UISref.tsx
+++ b/src/components/UISref.tsx
@@ -3,7 +3,7 @@
  * @module components
  */ /** */
 import * as React from 'react';
-import { Component, createElement, cloneElement, isValidElement, ValidationMap } from 'react';
+import { Component, cloneElement } from 'react';
 import * as PropTypes from 'prop-types';
 import * as _classNames from 'classnames';
 
@@ -12,7 +12,7 @@ import { extend, isFunction, TransitionOptions } from '@uirouter/core';
 import { UIRouterReact, UIRouterConsumer } from '../index';
 import { UIViewAddress, UIViewConsumer } from './UIView';
 import { UIRouterInstanceUndefinedError } from './UIRouter';
-import { UISrefActive, UISrefActiveConsumer } from './UISrefActive';
+import { UISrefActiveConsumer } from './UISrefActive';
 
 let classNames = _classNames;
 

--- a/src/components/UISref.tsx
+++ b/src/components/UISref.tsx
@@ -17,9 +17,6 @@ import { UISrefActiveConsumer } from './UISrefActive';
 let classNames = _classNames;
 
 export interface UISrefProps {
-  router: UIRouterReact;
-  addStateInfoToParentActive: Function;
-  parentUIView: UIViewAddress;
   children?: any;
   to: string;
   params?: { [key: string]: any };
@@ -27,7 +24,13 @@ export interface UISrefProps {
   className?: string;
 }
 
-class Sref extends Component<UISrefProps, any> {
+interface SrefProps extends UISrefProps {
+  router: UIRouterReact;
+  addStateInfoToParentActive: Function;
+  parentUIView: UIViewAddress;
+}
+
+class Sref extends Component<SrefProps, any> {
   // deregister function for parent UISrefActive
   deregister: Function;
   static propTypes = {
@@ -90,7 +93,7 @@ class Sref extends Component<UISrefProps, any> {
   }
 }
 
-export const UISref = props => (
+export const UISref = (props: UISrefProps) => (
   <UIRouterConsumer>
     {router => (
       <UIViewConsumer>


### PR DESCRIPTION
### Motivation

this PR fix following problems.

- UISref.d.ts has `UISrefProps` interface, but this is different from [documentation](https://ui-router.github.io/react/docs/0.4.0/interfaces/components.uisrefprops.html)
  - this interface has some internal property.
- `UISref` Component props has `any` props

### NOTE

this is breaking change in `UISrefProps` interface.
removed `router` , `addStateInfoToParentActive` ,  `parentUIView`.