### PR TITLE
fixes to support React.StrictMode

### DIFF
--- a/examples/typescript/index.tsx
+++ b/examples/typescript/index.tsx
@@ -55,17 +55,19 @@ const routerConfig = (router: UIRouterReact) => {
 
 let el = document.getElementById('react-app');
 let app = (
-  <UIRouter plugins={[pushStateLocationPlugin]} states={[home, child, nest]} config={routerConfig}>
-    <div>
-      <UISrefActive class="active">
-        <UISref to="home">
-          <a>Home</a>
-        </UISref>
-      </UISrefActive>
-      <UIView render={(Comp, props) => <Comp {...props} foo="bar" />}>
-        <p>Content will load here</p>
-      </UIView>
-    </div>
-  </UIRouter>
+  <React.StrictMode>
+    <UIRouter plugins={[pushStateLocationPlugin]} states={[home, child, nest]} config={routerConfig}>
+      <div>
+        <UISrefActive class="active">
+          <UISref to="home">
+            <a>Home</a>
+          </UISref>
+        </UISrefActive>
+        <UIView render={(Comp, props) => <Comp {...props} foo="bar" />}>
+          <p>Content will load here</p>
+        </UIView>
+      </div>
+    </UIRouter>
+  </React.StrictMode>
 );
 ReactDOM.render(app, el);

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -17,6 +17,6 @@
     "tsconfig-paths-webpack-plugin": "^3.0.4",
     "typescript": "2.8.3",
     "webpack": "^4.7.0",
-    "webpack-dev-server": "^3.1.4"
+    "webpack-dev-server": "3.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react": "^16.5.1",
     "react-dom": "^16.5.1",
     "react-test-renderer": "^16.5.1",
+    "tsconfig-paths-webpack-plugin": "^3.2.0",
     "ts-jest": "^23.1.3",
     "ts-loader": "^6.0.2",
     "typescript": "^3.0.1",
@@ -96,7 +97,7 @@
     "testRegex": "/__tests__/.*\\.(ts|tsx|js)$",
     "globals": {
       "ts-jest": {
-        "tsConfigFile": "../tsconfig.jest.json"
+        "tsConfigFile": "./tsconfig.jest.json"
       }
     }
   },

--- a/src/components/UIRouter.tsx
+++ b/src/components/UIRouter.tsx
@@ -44,21 +44,21 @@ export interface UIRouterState {
 
 /** @hidden */
 export const InstanceOrPluginsMissingError = new Error(`Router instance or plugins missing.
-You must either provide a location plugin via the plugins prop:
-
-<UIRouter plugins={[pushStateLocationPlugin]} states={[···]}>
-  <UIView />
-</UIRouter>
-
-or initialize the router yourself and pass the instance via props:
-
-const router = new UIRouterReact();
-router.plugin(pushStateLocationPlugin);
-···
-<UIRouter router={router}>
-  <UIView />
-</UIRouter>
-`);
+ You must either provide a location plugin via the plugins prop:
+ 
+ <UIRouter plugins={[pushStateLocationPlugin]} states={[···]}>
+   <UIView />
+ </UIRouter>
+ 
+ or initialize the router yourself and pass the instance via props:
+ 
+ const router = new UIRouterReact();
+ router.plugin(pushStateLocationPlugin);
+ ···
+ <UIRouter router={router}>
+   <UIView />
+ </UIRouter>
+ `);
 
 /** @hidden */
 export const UIRouterInstanceUndefinedError = new Error(
@@ -76,24 +76,27 @@ export class UIRouter extends Component<UIRouterProps, UIRouterState> {
 
   router: UIRouterReact;
 
-  constructor(props, context) {
-    super(props, context);
-    // check if a router instance is provided
-    if (props.router) {
-      this.router = props.router;
-    } else if (props.plugins) {
-      this.router = new UIRouterReact();
-      this.router.plugin(servicesPlugin);
-      props.plugins.forEach(plugin => this.router.plugin(plugin));
-      if (props.config) props.config(this.router);
-      (props.states || []).forEach(state => this.router.stateRegistry.register(state));
-    } else {
-      throw InstanceOrPluginsMissingError;
+  componentDidMount() {
+    if (!this.router) {
+      // check if a router instance is provided
+      if (this.props.router) {
+        this.router = this.props.router;
+      } else if (this.props.plugins) {
+        this.router = new UIRouterReact();
+        this.router.plugin(servicesPlugin);
+        this.props.plugins.forEach(plugin => this.router.plugin(plugin));
+        if (this.props.config) this.props.config(this.router);
+        (this.props.states || []).forEach(state => this.router.stateRegistry.register(state));
+      } else {
+        throw InstanceOrPluginsMissingError;
+      }
+
+      this.router.start();
+      this.forceUpdate();
     }
-    this.router.start();
   }
 
   render() {
-    return <UIRouterProvider value={this.router}>{this.props.children}</UIRouterProvider>;
+    return this.router ? <UIRouterProvider value={this.router}>{this.props.children}</UIRouterProvider> : null;
   }
 }

--- a/src/components/UIRouter.tsx
+++ b/src/components/UIRouter.tsx
@@ -3,10 +3,10 @@
  * @module components
  */ /** */
 import * as React from 'react';
-import { Component, Children } from 'react';
+import { Component } from 'react';
 import * as PropTypes from 'prop-types';
 
-import { UIRouterPlugin, servicesPlugin } from '@uirouter/core';
+import { servicesPlugin } from '@uirouter/core';
 
 import { UIRouterReact, ReactStateDeclaration } from '../index';
 

--- a/src/components/UISref.tsx
+++ b/src/components/UISref.tsx
@@ -44,7 +44,7 @@ class Sref extends Component<SrefProps, any> {
     className: PropTypes.string,
   };
 
-  componentWillMount() {
+  componentDidMount() {
     const addStateInfo = this.props.addStateInfoToParentActive;
     this.deregister = typeof addStateInfo === 'function' ? addStateInfo(this.props.to, this.props.params) : () => {};
     const router = this.props.router;
@@ -54,7 +54,9 @@ class Sref extends Component<SrefProps, any> {
   }
 
   componentWillUnmount() {
-    this.deregister();
+    if (this.deregister) {
+      this.deregister();
+    }
   }
 
   getOptions = () => {

--- a/src/components/UISrefActive.tsx
+++ b/src/components/UISrefActive.tsx
@@ -3,11 +3,11 @@
  * @module components
  */ /** */
 import * as React from 'react';
-import { Component, cloneElement, ValidationMap } from 'react';
+import { Component, cloneElement } from 'react';
 import * as PropTypes from 'prop-types';
 import * as _classNames from 'classnames';
 
-import { UIRouterReact, UISref, UIRouterConsumer } from '../index';
+import { UIRouterReact, UIRouterConsumer } from '../index';
 import { UIViewAddress } from './UIView';
 import { UIRouterInstanceUndefinedError } from './UIRouter';
 

--- a/src/components/UISrefActive.tsx
+++ b/src/components/UISrefActive.tsx
@@ -59,7 +59,7 @@ class SrefActive extends Component<UISrefActiveProps, any> {
     activeClasses: '',
   };
 
-  componentWillMount() {
+  componentDidMount() {
     const router = this.props.router;
     if (typeof router === 'undefined') {
       throw UIRouterInstanceUndefinedError;
@@ -69,7 +69,9 @@ class SrefActive extends Component<UISrefActiveProps, any> {
   }
 
   componentWillUnmount() {
-    this.deregister();
+    if (this.deregister) {
+      this.deregister();
+    }
   }
 
   addStateInfo = (stateName, stateParams) => {

--- a/src/components/UIView.tsx
+++ b/src/components/UIView.tsx
@@ -9,18 +9,14 @@ import {
   Component,
   ComponentClass,
   createContext,
-  FunctionComponent,
-  ReactElement,
+  SFC,
   ReactNode,
   StatelessComponent,
   ValidationMap,
   Validator,
   cloneElement,
   createElement,
-  isValidElement,
-  useEffect,
-  useRef,
-  useState,
+  isValidElement
 } from 'react';
 import * as PropTypes from 'prop-types';
 
@@ -97,7 +93,7 @@ export interface UIViewProps {
 export interface UIViewState {
   id?: number;
   loaded?: boolean;
-  component?: string | FunctionComponent<any> | ClassType<any, any, any> | ComponentClass<any>;
+  component?: string | SFC<any> | ClassType<any, any, any> | ComponentClass<any>;
   props?: any;
 }
 

--- a/src/components/__tests__/UISref.test.tsx
+++ b/src/components/__tests__/UISref.test.tsx
@@ -139,7 +139,8 @@ describe('<UISref>', () => {
     );
     await router.stateService.go('state');
     wrapper.update();
-    const stateServiceGoSpy = jest.spyOn(wrapper.instance().router.stateService, 'go');
+    // @ts-ignore
+    const stateServiceGoSpy = jest.spyOn(router.stateService, 'go');
     const link = wrapper.find('a');
     link.simulate('click');
     link.simulate('click', { button: 1 });
@@ -162,6 +163,7 @@ describe('<UISref>', () => {
       .find('Sref')
       .at(0);
     expect(uiSref.instance().context.parentUIViewAddress).toBeUndefined();
+    // @ts-ignore
     expect(uiSref.instance().getOptions().relative.name).toBe('');
   });
 });

--- a/src/components/__tests__/UISrefActive.test.tsx
+++ b/src/components/__tests__/UISrefActive.test.tsx
@@ -204,6 +204,7 @@ describe('<UISrefActive>', () => {
       .at(0)
       .instance();
     expect(instance.context.parentUIViewAddress).toBeUndefined();
+    // @ts-ignore
     expect(instance.states[0].state.name).toBe('parent.child1');
   });
 
@@ -232,6 +233,7 @@ describe('<UISrefActive>', () => {
       .at(0)
       .instance();
     expect(instance.context.parentUIViewAddress).toBeUndefined();
+    // @ts-ignore
     expect(instance.states.length).toBe(3);
   });
 
@@ -266,6 +268,7 @@ describe('<UISrefActive>', () => {
       .find('SrefActive')
       .at(0)
       .instance();
+    // @ts-ignore
     expect(instance.states.length).toBe(3);
 
     router.stateRegistry.register({
@@ -340,8 +343,10 @@ describe('<UISrefActive>', () => {
       .find('SrefActive')
       .at(0)
       .instance();
+    // @ts-ignore
     expect(instance.states.length).toBe(1);
     wrapper.setProps({ show: false });
+    // @ts-ignore
     expect(instance.states.length).toBe(0);
   });
 

--- a/src/components/__tests__/UIView.test.tsx
+++ b/src/components/__tests__/UIView.test.tsx
@@ -106,15 +106,14 @@ describe('<UIView>', () => {
       states.forEach(state => router.stateRegistry.register(state as ReactStateDeclaration));
     });
 
-    it('renders its State Component', () => {
+    it('renders its State Component', async () => {
       const wrapper = mount(
         <UIRouter router={router}>
           <UIView />
         </UIRouter>
       );
-      return router.stateService.go('parent').then(() => {
-        expect(wrapper.html()).toEqual(`<div><span>parent</span><div></div></div>`);
-      });
+      await router.stateService.go('parent');
+      expect(wrapper.update().html()).toEqual(`<div><span>parent</span><div></div></div>`);
     });
 
     it('injects the right props', async () => {
@@ -131,7 +130,9 @@ describe('<UIView>', () => {
       );
       await router.stateService.go('__state');
       wrapper.update();
+      // @ts-ignore
       expect(wrapper.find(Comp).props().myresolve).not.toBeUndefined();
+      // @ts-ignore
       expect(wrapper.find(Comp).props().transition).not.toBeUndefined();
     });
 
@@ -149,6 +150,7 @@ describe('<UIView>', () => {
       );
       await router.stateService.go('__state');
       wrapper.update();
+      // @ts-ignore
       expect(wrapper.find(Comp).props().foo).toBe('bar');
     });
 
@@ -208,9 +210,9 @@ describe('<UIView>', () => {
         </UIRouter>
       );
       await router.stateService.go('parent.child');
-      expect(wrapper.html()).toEqual(`<div><span>parent</span><span>child</span></div>`);
+      expect(wrapper.update().html()).toEqual(`<div><span>parent</span><span>child</span></div>`);
       await router.stateService.go('parent');
-      expect(wrapper.html()).toEqual(`<div><span>parent</span><div></div></div>`);
+      expect(wrapper.update().html()).toEqual(`<div><span>parent</span><div></div></div>`);
     });
 
     it('calls uiCanExit function of its State Component when unmounting', async () => {
@@ -239,9 +241,9 @@ describe('<UIView>', () => {
         </UIRouter>
       );
       await router.stateService.go('__state');
-      expect(wrapper.html()).toEqual('<span>UiCanExitHookComponent</span>');
+      expect(wrapper.update().html()).toEqual('<span>UiCanExitHookComponent</span>');
       await router.stateService.go('exit');
-      expect(wrapper.html()).toEqual('<span>exit</span>');
+      expect(wrapper.update().html()).toEqual('<span>exit</span>');
       expect(uiCanExitSpy).toBeCalled();
     });
 
@@ -273,9 +275,9 @@ describe('<UIView>', () => {
       );
       await router.stateService.go('__state');
       console.log(wrapper.html());
-      expect(wrapper.html()).toEqual('<span>UiCanExitHookComponent</span>');
+      expect(wrapper.update().html()).toEqual('<span>UiCanExitHookComponent</span>');
       await router.stateService.go('exit');
-      expect(wrapper.html()).toEqual('<span>exit</span>');
+      expect(wrapper.update().html()).toEqual('<span>exit</span>');
       expect(uiCanExitSpy).toBeCalled();
     });
 
@@ -300,7 +302,7 @@ describe('<UIView>', () => {
         </UIRouter>
       );
       await router.stateService.go('withrenderprop');
-      expect(wrapper.html()).toEqual(`<div><span>withrenderprop</span><span>bar</span></div>`);
+      expect(wrapper.update().html()).toEqual(`<div><span>withrenderprop</span><span>bar</span></div>`);
     });
 
     it('unmounts the State Component when calling stateService.reload(true)', async () => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -2,8 +2,8 @@
  * @reactapi
  * @module react
  */ /** */
-import { UIRouter, PathNode, services } from '@uirouter/core';
-import { ReactViewDeclaration, ReactStateDeclaration } from './interface';
+import { UIRouter, PathNode } from '@uirouter/core';
+import { ReactViewDeclaration } from './interface';
 import { ReactViewConfig, reactViewsBuilder } from './reactViews';
 
 /**

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -2,9 +2,9 @@
  * @reactapi
  * @module react
  */ /** */
-import { Component, ReactElement, StatelessComponent, ComponentClass, ClassicComponentClass } from 'react';
+import { StatelessComponent, ComponentClass, ClassicComponentClass } from 'react';
 
-import { StateDeclaration, _ViewDeclaration, ParamDeclaration, IInjectable, Transition } from '@uirouter/core';
+import { StateDeclaration, _ViewDeclaration, Transition } from '@uirouter/core';
 
 /**
  * The StateDeclaration object is used to define a state or nested state.

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,5 +1,5 @@
 {
-  "compilerOption": {
+  "compilerOptions": {
     "jsx": "react",
     "module": "commonjs",
     "target": "es6"


### PR DESCRIPTION
*resolves issue #463*
*repeat of PR [#499](https://github.com/ui-router/react/pull/499)*

In anticipation for React suspense and concurrent mode, it is advisable to test with `<React.StrictMode>` and resolve any issues.

- Wrap example in `<React.StrictMode>`
- Switch `componentWillMount` to `componentDidMount`
- Switch `UIRouter` component constructor to `componentDidMount`
- fix minor build and test issues