### PR TITLE
Refactor UIView for compatibility with @uirouter/react-hybrid.

### DIFF
--- a/src/components/UIRouter.tsx
+++ b/src/components/UIRouter.tsx
@@ -20,6 +20,8 @@ import { ReactStateDeclaration } from '../interface';
  * ```
  */
 export const UIRouterContext = React.createContext<UIRouterReact>(undefined);
+/** @deprecated use [[useRouter]] or React.useContext(UIRouterContext) */
+export const UIRouterConsumer = UIRouterContext.Consumer;
 
 export interface UIRouterProps {
   plugins?: Array<PluginFactory<UIRouterPlugin>>;

--- a/src/components/UIRouter.tsx
+++ b/src/components/UIRouter.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { useRef } from 'react';
 
-import { UIRouterPlugin, servicesPlugin, PluginFactory } from '@uirouter/core';
+import { UIRouter as _UIRouter, UIRouterPlugin, servicesPlugin, PluginFactory } from '@uirouter/core';
 
 import { UIRouterReact } from '../core';
 import { ReactStateDeclaration } from '../interface';
@@ -19,8 +19,8 @@ import { ReactStateDeclaration } from '../interface';
  * </UIRouterContext.Consumer>
  * ```
  */
-export const UIRouterContext = React.createContext<UIRouterReact>(undefined);
-/** @deprecated use [[useRouter]] or React.useContext(UIRouterContext) */
+export const UIRouterContext = React.createContext<_UIRouter>(undefined);
+  /** @deprecated use [[useRouter]] or React.useContext(UIRouterContext) */
 export const UIRouterConsumer = UIRouterContext.Consumer;
 
 export interface UIRouterProps {

--- a/src/components/UIView.tsx
+++ b/src/components/UIView.tsx
@@ -95,6 +95,8 @@ export const TransitionPropCollisionError =
 
 /** @internalapi */
 export const UIViewContext = createContext<UIViewAddress>(undefined);
+/** @deprecated use [[useParentView]] or React.useContext(UIViewContext) */
+export const UIViewConsumer = UIViewContext.Consumer;
 
 /** @hidden */
 function useResolvesWithStringTokens(resolveContext: ResolveContext, injector: UIInjector) {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,6 +8,7 @@
  */
 export { useCurrentStateAndParams } from './useCurrentStateAndParams';
 export { useOnStateChanged } from './useOnStateChanged';
+export { useParentView } from './useParentView';
 export { useRouter } from './useRouter';
 export { useSref } from './useSref';
 export { useSrefActive } from './useSrefActive';

--- a/src/hooks/useIsActive.ts
+++ b/src/hooks/useIsActive.ts
@@ -1,14 +1,14 @@
 /** @packageDocumentation @reactapi @module react_hooks */
 
 import { useEffect, useMemo, useState } from 'react';
-import { UIRouterReact } from '../core';
+import { UIRouter } from '@uirouter/core';
 import { useDeepObjectDiff } from './useDeepObjectDiff';
 import { useOnStateChanged } from './useOnStateChanged';
 import { useParentView } from './useParentView';
 import { useRouter } from './useRouter';
 
 /** @hidden */
-function checkIfActive(router: UIRouterReact, stateName: string, params: object, relative: string, exact: boolean) {
+function checkIfActive(router: UIRouter, stateName: string, params: object, relative: string, exact: boolean) {
   return exact
     ? router.stateService.is(stateName, params, { relative })
     : router.stateService.includes(stateName, params, { relative });

--- a/src/hooks/useParentView.ts
+++ b/src/hooks/useParentView.ts
@@ -4,7 +4,7 @@ import { useContext, useMemo } from 'react';
 import { UIViewAddress, UIViewContext } from '../components';
 import { useRouter } from './useRouter';
 
-/** Gets the parent UIViewAddress from context, or the root UIViewAddress */
+/** @internalapi Gets the parent UIViewAddress from context, or the root UIViewAddress */
 export function useParentView(): UIViewAddress {
   const router = useRouter();
   const parentUIViewContext: UIViewAddress = useContext(UIViewContext);

--- a/src/hooks/useRouter.ts
+++ b/src/hooks/useRouter.ts
@@ -1,7 +1,7 @@
 /** @packageDocumentation @reactapi @module react_hooks */
 
 import { useContext } from 'react';
-import { UIRouterReact } from '../core';
+import { UIRouter } from '@uirouter/core';
 import { UIRouterContext } from '../components/UIRouter';
 
 /** @hidden */
@@ -25,7 +25,7 @@ export const UIRouterInstanceUndefinedError = `UIRouter instance is undefined. D
  * }
  * ```
  */
-export function useRouter(): UIRouterReact {
+export function useRouter(): UIRouter {
   const router = useContext(UIRouterContext);
   if (!router) {
     throw new Error(UIRouterInstanceUndefinedError);

--- a/src/hooks/useSref.ts
+++ b/src/hooks/useSref.ts
@@ -2,9 +2,8 @@
 
 import * as React from 'react';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { isString, StateDeclaration, TransitionOptions } from '@uirouter/core';
+import { isString, StateDeclaration, TransitionOptions, UIRouter } from '@uirouter/core';
 import { UISrefActiveContext } from '../components';
-import { UIRouterReact } from '../core';
 import { useDeepObjectDiff } from './useDeepObjectDiff';
 import { useParentView } from './useParentView';
 import { useRouter } from './useRouter';
@@ -18,7 +17,7 @@ export interface LinkProps {
 export const IncorrectStateNameTypeError = `The state name passed to useSref must be a string.`;
 
 /** @hidden Gets all StateDeclarations that are registered in the StateRegistry. */
-function useListOfAllStates(router: UIRouterReact) {
+function useListOfAllStates(router: UIRouter) {
   const initial = useMemo(() => router.stateRegistry.get(), []);
   const [states, setStates] = useState(initial);
   useEffect(() => router.stateRegistry.onStatesChanged(() => setStates(router.stateRegistry.get())), []);
@@ -26,7 +25,7 @@ function useListOfAllStates(router: UIRouterReact) {
 }
 
 /** @hidden Gets the StateDeclaration that this sref targets */
-function useTargetState(router: UIRouterReact, stateName: string, relative: string): StateDeclaration {
+function useTargetState(router: UIRouter, stateName: string, relative: string): StateDeclaration {
   // Whenever any states are added/removed from the registry, get the target state again
   const allStates = useListOfAllStates(router);
   return useMemo(() => {


### PR DESCRIPTION
- Adds a ref imperative hook for react-hybrid to access
- Fixes excess renders of functional component
- Restores class component wrapper for react-hybrid to monkey patch (hopefully temporarily)
- Switches useRouter signature from returning a `UIRouterReact` to a `UIRouter` (from core)