### PR TITLE
fix(sref): do not handle clicks if the dom element has a 'target' attribute Also do not handle clicks if shift or alt is being held down.

### DIFF
--- a/src/components/__tests__/UISref.test.tsx
+++ b/src/components/__tests__/UISref.test.tsx
@@ -94,7 +94,7 @@ describe('<UISref>', () => {
 
   it('calls the child elements onClick function and honors e.preventDefault()', async () => {
     const goSpy = jest.spyOn(router.stateService, 'go');
-    const onClickSpy = jest.fn(e => e.preventDefault());
+    const onClickSpy = jest.fn((e) => e.preventDefault());
     const wrapper = mountInRouter(
       <UISref to="state2">
         <a onClick={onClickSpy}>state2</a>
@@ -106,7 +106,7 @@ describe('<UISref>', () => {
     expect(goSpy).not.toHaveBeenCalled();
   });
 
-  it("doesn't trigger a transition when middle-clicked/ctrl+clicked", async () => {
+  it("doesn't trigger a transition when middle-clicked", async () => {
     const stateServiceGoSpy = jest.spyOn(router.stateService, 'go');
     const wrapper = mountInRouter(
       <UISref to="state2">
@@ -119,9 +119,44 @@ describe('<UISref>', () => {
     expect(stateServiceGoSpy).toHaveBeenCalledTimes(1);
 
     link.simulate('click', { button: 1 });
-    link.simulate('click', { metaKey: true });
-    link.simulate('click', { ctrlKey: true });
-
     expect(stateServiceGoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesn't trigger a transition when ctrl/meta/shift/alt+clicked", async () => {
+    const stateServiceGoSpy = jest.spyOn(router.stateService, 'go');
+    const wrapper = mountInRouter(
+      <UISref to="state2">
+        <a>state2</a>
+      </UISref>
+    );
+
+    const link = wrapper.find('a');
+    link.simulate('click');
+    expect(stateServiceGoSpy).toHaveBeenCalledTimes(1);
+
+    link.simulate('click', { ctrlKey: true });
+    expect(stateServiceGoSpy).toHaveBeenCalledTimes(1);
+
+    link.simulate('click', { metaKey: true });
+    expect(stateServiceGoSpy).toHaveBeenCalledTimes(1);
+
+    link.simulate('click', { shiftKey: true });
+    expect(stateServiceGoSpy).toHaveBeenCalledTimes(1);
+
+    link.simulate('click', { altKey: true });
+    expect(stateServiceGoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesn't trigger a transition when the anchor has a 'target' attribute", async () => {
+    const stateServiceGoSpy = jest.spyOn(router.stateService, 'go');
+    const wrapper = mountInRouter(
+      <UISref to="state2">
+        <a target="_blank">state2</a>
+      </UISref>
+    );
+
+    const link = wrapper.find('a');
+    link.simulate('click');
+    expect(stateServiceGoSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useSref.ts
+++ b/src/hooks/useSref.ts
@@ -1,7 +1,7 @@
 /** @packageDocumentation @reactapi @module react_hooks */
 
 import * as React from 'react';
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { ReactHTMLElement, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { isString, StateDeclaration, TransitionOptions, UIRouter } from '@uirouter/core';
 import { UISrefActiveContext } from '../components';
 import { useDeepObjectDiff } from './useDeepObjectDiff';
@@ -84,7 +84,9 @@ export function useSref(stateName: string, params: object = {}, options: Transit
 
   const onClick = useCallback(
     (e: React.MouseEvent) => {
-      if (!e.defaultPrevented && !(e.button == 1 || e.metaKey || e.ctrlKey)) {
+      const targetAttr = (e.target as any)?.attributes?.target;
+      const modifierKey = e.button >= 1 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey;
+      if (!e.defaultPrevented && targetAttr == null && !modifierKey) {
         e.preventDefault();
         router.stateService.go(stateName, paramsMemo, optionsMemo);
       }


### PR DESCRIPTION
Copying behavior from uirouter for angularjs, if any target attribute is present, or shift/alt/meta/ctrl is held down, the transition isn't started and it falls back to native browser behavior


Fixes #786 
