### PR TITLE
reverted import * as _classNames

### DIFF
--- a/examples/typescript/components/Nest.tsx
+++ b/examples/typescript/components/Nest.tsx
@@ -7,7 +7,7 @@ interface NextInjectedProps extends UIViewInjectedProps {
 
 export class Nest extends React.Component<NextInjectedProps, any> {
   uiCanExit = () => {
-    return new Promise(resolve => {
+    return new Promise<void>((resolve) => {
       setTimeout(() => {
         resolve();
       }, 1000);

--- a/src/components/UISref.tsx
+++ b/src/components/UISref.tsx
@@ -1,13 +1,10 @@
 import { isFunction, TransitionOptions } from '@uirouter/core';
 
-import * as _classNames from 'classnames';
+import classNames from 'classnames';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { cloneElement, useCallback, useMemo } from 'react';
 import { useSref } from '../hooks/useSref';
-
-/** @hidden */
-let classNames = _classNames;
 
 export interface UISrefProps {
   children?: any;

--- a/src/components/UISrefActive.tsx
+++ b/src/components/UISrefActive.tsx
@@ -1,12 +1,8 @@
 import * as React from 'react';
 import { useState, useCallback, useContext, useMemo, cloneElement } from 'react';
-import * as _classNames from 'classnames';
+import classNames from 'classnames';
 
 import { useCurrentStateAndParams, useRouter } from '../hooks';
-
-/** @hidden */
-let classNames = _classNames;
-
 export interface UISrefActiveState {
   stateName: string;
   params: object;


### PR DESCRIPTION
While there was an issue in the past with Rollup (#33), based on my tests so far, it seems to be working properly now.
