### PR TITLE
Pull latest version of @uirouter/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "url": "https://github.com/ui-router/react.git"
   },
   "dependencies": {
-    "@uirouter/core": "6.0.7",
+    "@uirouter/core": "^6.0.7",
     "classnames": "^2.3.1",
     "prop-types": "^15.6.1"
   },


### PR DESCRIPTION
Currently `@uirouter/react` is pulling an older fixed version or `@uirouter/core` and this is causing odd behavior and type errors. When I remove `node_modules/@uirouter/react/node_modules/@uirouter/core` everything works normally.