### PR TITLE
#1224 | useSref | updated onClick to check target from currentPropert…

### DIFF
--- a/src/hooks/__tests__/useSref.test.tsx
+++ b/src/hooks/__tests__/useSref.test.tsx
@@ -20,6 +20,15 @@ const Link = ({ to, params = undefined, children = undefined, target = undefined
   );
 };
 
+const LinkWithChildElement = ({ to, params = undefined, children = undefined, target = undefined }) => {
+  const sref = useSref(to, params);
+  return (
+    <a data-testid="anchor" {...sref} target={target}>
+      <div data-testid="inner-child">{children}</div>
+    </a>
+  );
+};
+
 describe('useSref', () => {
   let { router, routerGo, mountInRouter } = makeTestRouter([]);
   beforeEach(() => ({ router, routerGo, mountInRouter } = makeTestRouter([state, state2, state3])));
@@ -81,6 +90,16 @@ describe('useSref', () => {
       const rendered = mountInRouter(<Link to="state" target="_blank" />);
 
       rendered.getByTestId('anchor').click();
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('does not get called if the underlying DOM element that has a child has a "target" attribute', () => {
+      const spy = jest.spyOn(router.stateService, 'go');
+      const rendered = mountInRouter(<LinkWithChildElement to="state" target="_blank" />);
+
+      // clicking on the div to mimick the actual behaviour
+      // behaviour: when anchor has a child element and user clicks on anchor, the event is fired on child element rather than on anchor
+      rendered.getByTestId('inner-child').click();
       expect(spy).not.toHaveBeenCalled();
     });
   });

--- a/src/hooks/useSref.ts
+++ b/src/hooks/useSref.ts
@@ -90,7 +90,13 @@ export function useSref(stateName: string, params: object = {}, options: Transit
 
   const onClick = useCallback(
     (e: React.MouseEvent) => {
-      const targetAttr = (e.target as any)?.attributes?.target;
+      /* For scenario where we specify target="_blank" on a link that has a div as a child, to use browser's default onClick behavior,
+          the onClick event gets triggered on the div rather than the anchor tag.
+          The actual target is present inside the currentTarget property instead. So, targetAttr should be assigned from currentTarget,
+          so that router's go method does not get called and browser's default onClick behavior is triggered 
+          currentTarget will always be set irrespective of anchor contains a child or not*/
+
+      const targetAttr = (e.currentTarget as any)?.attributes?.target;
       const modifierKey = e.button >= 1 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey;
       if (!e.defaultPrevented && targetAttr == null && !modifierKey) {
         e.preventDefault();


### PR DESCRIPTION
- Issue Example:
    - https://codesandbox.io/p/sandbox/uirouter-react-ussref-blank-target-not-working-with-div-inside-a-992y2s
- Issue:
   - useSref handles click when anchor element contains a child element. This is an issue when the user wants the browser to handle the onClick event, by providing a target attribute.

- Use Case:
   - The user wants the link to open in a new tab

- Cause:
   - In Fix https://github.com/ui-router/react/pull/799 the targetAttr (line#87) is captured from e.target assuming that the mouse event got triggered from the anchor. But when there is a child element present inside the anchor element, the mouse event triggers the child element. The child element does not have a target attribute, which makes useSref handle the onClick.

- Fix:
   - Although the target attribute is not present in e.target, it is in e.currentTarget. So we should check for e.currentTarget when getting targetAttr